### PR TITLE
Make sure Magento2 does not complain about the type of CurrentUrlRewriter passed to Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator::__construct()

### DIFF
--- a/Logger/Logger.php
+++ b/Logger/Logger.php
@@ -14,7 +14,7 @@ namespace Bangerkuwranger\GtidSafeUrlRewriteFallback\Logger;
 class Logger extends \Monolog\Logger
 {
 
-    public function prettyLog($message, $file)
+    public function prettyLog($message, $file = null)
     {
         if ($file) {
             $fileName = BP. DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . 'log'. DIRECTORY_SEPARATOR . $file .'_Request.log';

--- a/Model/Rewrite/CatalogUrlRewrite/Category/CurrentUrlRewritesRegenerator.php
+++ b/Model/Rewrite/CatalogUrlRewrite/Category/CurrentUrlRewritesRegenerator.php
@@ -14,7 +14,7 @@ namespace Bangerkuwranger\GtidSafeUrlRewriteFallback\Model\Rewrite\CatalogUrlRew
 use Bangerkuwranger\GtidSafeUrlRewriteFallback\Model\Rewrite\CatalogUrlRewrite\CategoryUrlRewriteGenerator;
 use Magento\UrlRewrite\Model\OptionProvider;
 
-class CurrentUrlRewritesRegenerator
+class CurrentUrlRewritesRegenerator extends \Magento\CatalogUrlRewrite\Model\Category\CurrentUrlRewritesRegenerator
 {
     /** @var \Magento\CatalogUrlRewrite\Model\CategoryUrlPathGenerator */
     protected $categoryUrlPathGenerator;

--- a/Model/Rewrite/CatalogUrlRewrite/Product/CurrentUrlRewritesRegenerator.php
+++ b/Model/Rewrite/CatalogUrlRewrite/Product/CurrentUrlRewritesRegenerator.php
@@ -27,7 +27,7 @@ use Magento\UrlRewrite\Model\MergeDataProviderFactory;
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class CurrentUrlRewritesRegenerator
+class CurrentUrlRewritesRegenerator extends \Magento\CatalogUrlRewrite\Model\Product\CurrentUrlRewritesRegenerator
 {
     /**
      * @var Product

--- a/Model/Rewrite/CatalogUrlRewrite/Product/CurrentUrlRewritesRegenerator.php
+++ b/Model/Rewrite/CatalogUrlRewrite/Product/CurrentUrlRewritesRegenerator.php
@@ -17,7 +17,7 @@ use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
 use Magento\UrlRewrite\Model\OptionProvider;
 use Magento\CatalogUrlRewrite\Model\ObjectRegistry;
 use Magento\UrlRewrite\Model\UrlFinderInterface;
-use Magento\UrlRewrite\Model\ProductUrlRewriteGenerator;
+use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
 use Magento\CatalogUrlRewrite\Model\ProductUrlPathGenerator;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewriteFactory;
 use Bangerkuwranger\GtidSafeUrlRewriteFallback\Model\Rewrite\CatalogUrlRewrite\Map\UrlRewriteFinder;


### PR DESCRIPTION
In Magento 2.2.3 this was a problem making it impossible to save products